### PR TITLE
Move bender.defer() inside the require call.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6,12 +6,10 @@
 ( function( window, bender ) {
 	'use strict';
 
-	var unlock = bender.defer(),
-		originalRequire = window.require;
-
-	// TODO what if require is never called?
 	bender.require = function( deps, callback ) {
-		originalRequire( deps, function() {
+		var unlock = bender.defer();
+
+		window.require( deps, function() {
 			callback.apply( null, arguments );
 			unlock();
 		} );


### PR DESCRIPTION
The way this is executed now causes problems when `require` is not called at all in the test.

Example case:
https://github.com/cksource/ckeditor-plugin-a11ychecker/issues/212

This pull request is an attempt to solve this issue. Test for Accessibility Checker are not affected negatively due to this change.
